### PR TITLE
cli: `where` and `about` stubs to test cli structure and behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-warrior-bot = "warrior_bot.cli:main"
+warrior-bot = "warrior_bot.cli:cli"
+
+[tool.black]
+line-length = 79

--- a/warrior_bot/cli.py
+++ b/warrior_bot/cli.py
@@ -1,19 +1,19 @@
-"""Command-line interface for Warrior Bot."""
+"""CLI Entry point"""
 
 import click
 
+from .core.about import about
+from .core.where import where
 
-@click.command()
-@click.argument("query", nargs=-1, required=False)
+
+@click.group()
 @click.version_option()
-def main(query):
-    """Warrior Bot - Your Wayne State University terminal assistant."""
-    if query:
-        question = " ".join(query)
-        click.echo(f"You asked: {question}")
-    else:
-        click.echo("Warrior Bot ready. Try: warrior-bot <your question>")
+def cli():
+    pass
 
+
+cli.add_command(about)
+cli.add_command(where)
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/warrior_bot/core/about.py
+++ b/warrior_bot/core/about.py
@@ -1,0 +1,7 @@
+import click
+
+
+@click.command()
+def about():
+    """Official reference for warrior-bot"""
+    click.echo("Official reference for warrior-bot.")

--- a/warrior_bot/core/where.py
+++ b/warrior_bot/core/where.py
@@ -1,0 +1,29 @@
+import difflib
+
+import click
+
+# placeholder to test fuzzy matching
+# ideally here we'd actually just pull from a .json file or something similar
+LOCATIONS = {
+    "panda express": "Panda express is located in the Student Center",
+    "library": "UGL is across the Student Center",
+}
+
+
+@click.command()
+@click.argument("loc_query", nargs=-1)
+def where(loc_query):
+    """Find POI's around campus."""
+    if not loc_query:
+        click.echo("Please specify a location.")
+
+    query = " ".join(loc_query).lower().strip()
+    matches = difflib.get_close_matches(
+        query, LOCATIONS.keys(), n=1, cutoff=0.6
+    )
+
+    if matches:
+        location = matches[0]
+        click.echo(LOCATIONS[location])
+    else:
+        click.echo("No documented match found.")


### PR DESCRIPTION
- `where` command
  - currently does fuzzy matching on a dict. As stated in the code, we'd wanna talk about how exactly we're going to actually list and organize locations. But this general structure for matching on the keys I think should work okay long term
- `about`
  - Doesn't do much, but should get us started as we expand the CLI. 
  - Note: The docstring after defining a function is actually automatically wired into `--help`. Kinda cool. [See here](https://click.palletsprojects.com/en/stable/documentation/) 
    - <img width="425" height="222" alt="image" src="https://github.com/user-attachments/assets/ca5da841-1d9a-4f63-8a56-0017007c1e7c" />

<br>

I also adjusted  `pyproject.toml`. `flake8` was enforcing 79 chars for lines but `black` kept re-formatting into 81. This should get them to agree with eachother.