### PR TITLE
feat(#21): `appdirs` for platform agnostic user directions for cache

### DIFF
--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           python-version: "3.13"
       - run: |
-          pip install mypy pytest types-click types-setuptools types-beautifulsoup4
+          pip install mypy pytest types-click types-setuptools types-beautifulsoup4 types-appdirs
       - run: mypy --strict .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 bs4
 types-beautifulsoup4
+appdirs

--- a/warrior_bot/cli.py
+++ b/warrior_bot/cli.py
@@ -6,6 +6,7 @@ import click
 
 from warrior_bot.core.about import about
 from warrior_bot.core.data_handler import JSONHandler
+from warrior_bot.core.refresh import sync
 from warrior_bot.core.where import where
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -22,6 +23,7 @@ def cli() -> None:
 
 cli.add_command(about)
 cli.add_command(where)
+cli.add_command(sync)
 
 # alias to allow the naming of our entry point as cli.py
 main = cli

--- a/warrior_bot/core/refresh.py
+++ b/warrior_bot/core/refresh.py
@@ -1,0 +1,61 @@
+"""
+Command to refresh/sync data parsing for any given service
+"""
+
+import importlib.metadata
+from typing import Any, Callable
+
+import click
+
+from warrior_bot.utils.faculty_parser import build_faculty_cache
+
+warrior_bot_version = importlib.metadata.version("warrior-bot")
+
+
+def _get_version(*sub: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """
+    Retrieve the current version of warrior-bot
+    """
+
+    def dec(obj: Callable[..., Any]) -> Callable[..., Any]:
+        doc = obj.__doc__ or ""
+        obj.__doc__ = doc.format(*sub)
+        return obj
+
+    return dec
+
+
+@click.command()
+@click.argument("service", nargs=-1)
+@_get_version(warrior_bot_version)
+def sync(service: str) -> None:
+    """
+    Manually refresh data parsing services\n
+    warrior-bot version: {0} currently handles the following services:\n
+        staff:\n
+          - Parses https://bulletins.wayne.edu/faculty/
+    """
+    text = " ".join(service).strip()
+    if not text:
+        click.echo(
+            click.style(
+                "Please provide a valid warrior-bot service to reresh.\n"
+                "Run wb sync --help for a list of services",
+                fg="red",
+            )
+        )
+        return
+
+    target = service[0].strip().lower()
+
+    if target == "staff":
+        build_faculty_cache()
+        click.echo(click.style("Staff cache has been successfully built!", fg="green"))
+        return
+
+    click.echo(
+        click.style(
+            f"Unknown service: {target}",
+            fg="red",
+        )
+    )

--- a/warrior_bot/utils/faculty_lookup.py
+++ b/warrior_bot/utils/faculty_lookup.py
@@ -31,7 +31,6 @@ class StaffLookup:
     DIR_URL = "https://wayne.edu/people?type=people&q="  # Directory search URL
     STAFF_URL = "https://wayne.edu/people/"  # Base URL for staff profiles
     MAX_PAGES = 5  # Amount of pages _fetch_soup_dir will look through.
-    MAX_SEARCH_OPTIONS = 50  # Given options to the user
 
     def __init__(self) -> None:
         pass
@@ -58,14 +57,13 @@ class StaffLookup:
                 html: str = urlopen(url).read()
                 data: BeautifulSoup = BeautifulSoup(html, features="html.parser")
 
-                # Kill all script and style elements
                 for tag in soup(["script", "style"]):
                     tag.extract()
 
                 soup.append(data)
 
                 i += 1
-            except:
+            except Exception:
                 break
 
         return soup
@@ -81,7 +79,6 @@ class StaffLookup:
         html: str = urlopen(url).read()
         soup: BeautifulSoup = BeautifulSoup(html, features="html.parser")
 
-        # Kill all script and style elements
         for tag in soup(["script", "style"]):
             tag.extract()
 

--- a/warrior_bot/utils/faculty_parser.py
+++ b/warrior_bot/utils/faculty_parser.py
@@ -126,7 +126,7 @@ def build_faculty_cache(output_path: str | None = None) -> list[dict[str, str | 
         List of faculty name dictionaries that were saved.
     """
     if output_path is None:
-        output_path = os.path.join(os.path.dirname(__file__), "..", "data", CACHE_FILE)
+        output_path = get_cache_path()
 
     html = fetch_bulletin_html()
     raw_names = parse_raw_names(html)
@@ -142,7 +142,6 @@ def build_faculty_cache(output_path: str | None = None) -> list[dict[str, str | 
                 seen.add(key)
                 faculty.append(asdict(parsed))
 
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, "w") as f:
         json.dump(faculty, f, indent=2)
 


### PR DESCRIPTION
closes #21 
closes #22 

Also adjusts the CI for `appdirs` types